### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/Miriam/assets/vendor/php-email-form/validate.js
+++ b/Miriam/assets/vendor/php-email-form/validate.js
@@ -74,7 +74,7 @@
 
   function displayError(thisForm, error) {
     thisForm.querySelector('.loading').classList.remove('d-block');
-    thisForm.querySelector('.error-message').innerHTML = error;
+    thisForm.querySelector('.error-message').textContent = error;
     thisForm.querySelector('.error-message').classList.add('d-block');
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/GabrielFraga962/Miriam_Technologies_App/security/code-scanning/1](https://github.com/GabrielFraga962/Miriam_Technologies_App/security/code-scanning/1)

To fix the issue, the `error` variable should be sanitized or escaped before being assigned to the `innerHTML` property. This ensures that any special characters or HTML tags in the error message are treated as plain text rather than executable code. The best approach is to use a utility function like `textContent` for escaping or a library like `DOMPurify` for sanitization.

In this case, we will replace the use of `innerHTML` with `textContent`, which automatically escapes any HTML or JavaScript in the error message. This change ensures that the error message is displayed as plain text, eliminating the risk of XSS.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
